### PR TITLE
Use travis-ci to run tests on every PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 4
+  - 6

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # magic-cfn-resources
 
+[![Build Status](https://travis-ci.org/mapbox/magic-cfn-resources.svg?branch=master)](https://travis-ci.org/mapbox/magic-cfn-resources)
+
 ![](./assets/magicspaghetti.gif)
 
 Builds [Lambda-backed custom Cloudformation resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-lambda.html). When you use `magic-cfn-resources`'s `build` method, a Lambda function is created in your stack and used to build a custom resource. Resources that can be built with `magic-cfn-resources` are: `SnsSubscription`, `DynamoDBStreamLabel`, `StackOutputs`, and `SpotFleet`.
@@ -64,7 +66,7 @@ const SnsSubscription = magicCfnResources.build({
     SnsTopicArn: 'Topic Arn', // the ARN of the SNS Topic you are subscribing to
     Protocol: 'Protocol', // the SNS protocol, i.e. 'sqs', 'email'
     Endpoint: 'Endpoint' // the endpoint you are subscribing
-  } 
+  }
 });
 ```
 
@@ -79,7 +81,7 @@ const DynamoDBStreamLabel = magicCfnResources.build({
   Properties: {
     TableName: 'Name of Table', // the name of the DynamoDB table
     TableRegion: 'Region' // the region of the DynamoDB table i.e.: 'us-east-1'
-  } 
+  }
 });
 ```
 
@@ -94,7 +96,7 @@ const StackOutputs = magicCfnResources.build({
   Properties: {
     StackName: 'Name', // name of the CloudFormation stack
     StackRegion: 'region' // region of the CloudFormation stack i.e.: 'us-east-1'
-  } 
+  }
 });
 ```
 
@@ -109,7 +111,7 @@ const SpotFleet = magicCfnResources.build({
   Properties: {
     SpotFleetRequestConfigData: { }, // object with SpotFleet configuration specifics
     SpotFleetRegion: 'region', // region of the SpotFleet i.e.: 'us-east-1'
-  } 
+  }
 });
 ```
 

--- a/test/dynamodb-stream-label.test.js
+++ b/test/dynamodb-stream-label.test.js
@@ -14,7 +14,7 @@ test('[dynamodb-stream-label] create handles errors', assert => {
   AWS.stub('DynamoDB', 'describeTable', (opts, cb) => {
     assert.deepEquals(opts, { TableName: 'special-table' }, 'describeTable params');
     return cb(new Error('random error'));
-  }); 
+  });
 
   const stream = new DynamoDBStreamLabel('special-table', 'us-east-1');
 
@@ -30,16 +30,16 @@ test('[dynamodb-stream-label] create handles success', assert => {
     assert.deepEquals(opts, { TableName: 'special-table' }, 'describeTable params');
     return cb(null, {
       Table: {
-        LatestStreamLabel: (new Date(2017, 2, 2)).toISOString()
+        LatestStreamLabel: '2017-03-02T05:00:00.000Z'
       }
     });
-  }); 
+  });
 
   const stream = new DynamoDBStreamLabel('special-table', 'us-east-1');
 
   stream.create((err, label) => {
     assert.ifError(err, 'should not error');
-    assert.equals(label, '2017-03-02T08:00:00.000Z', 'stream label');
+    assert.equals(label, '2017-03-02T05:00:00.000Z', 'stream label');
     AWS.DynamoDB.restore();
     assert.end();
   });
@@ -51,7 +51,7 @@ test('[dynamodb-stream-label] create handles missing stream label', assert => {
     return cb(null, {
       Table: {}
     });
-  }); 
+  });
 
   const stream = new DynamoDBStreamLabel('special-table', 'us-east-1');
 
@@ -67,16 +67,16 @@ test('[dynamodb-stream-label] update does the same thing as create', assert => {
     assert.deepEquals(opts, { TableName: 'special-table' }, 'describeTable params');
     return cb(null, {
       Table: {
-        LatestStreamLabel: (new Date(2017, 2, 2)).toISOString()
+        LatestStreamLabel: '2017-03-02T05:00:00.000Z'
       }
     });
-  }); 
+  });
 
   const stream = new DynamoDBStreamLabel('special-table', 'us-east-1');
 
   stream.update((err, label) => {
     assert.ifError(err, 'should not error');
-    assert.equals(label, '2017-03-02T08:00:00.000Z', 'stream label');
+    assert.equals(label, '2017-03-02T05:00:00.000Z', 'stream label');
     AWS.DynamoDB.restore();
     assert.end();
   });
@@ -87,10 +87,10 @@ test('[dynamodb-stream-label] delete does nothing', assert => {
     assert.deepEquals(opts, { TableName: 'special-table' }, 'describeTable params');
     return cb(null, {
       Table: {
-        LatestStreamLabel: (new Date(2017, 2, 2)).toISOString()
+        LatestStreamLabel: '2017-03-02T05:00:00.000Z'
       }
     });
-  }); 
+  });
 
   const stream = new DynamoDBStreamLabel('special-table', 'us-east-1');
 
@@ -106,10 +106,10 @@ test('[dynamodb-stream-label] manage parses events and relays LatestStreamLabel 
     assert.deepEquals(opts, { TableName: 'special-table' }, 'describeTable params');
     return cb(null, {
       Table: {
-        LatestStreamLabel: (new Date(2017, 2, 2)).toISOString()
+        LatestStreamLabel: '2017-03-02T05:00:00.000Z'
       }
     });
-  }); 
+  });
 
   http.request = (options, cb) => {
     return {
@@ -137,7 +137,7 @@ test('[dynamodb-stream-label] manage parses events and relays LatestStreamLabel 
   }, {
     done: (err, body) => {
       assert.ifError(err, 'should not error');
-      assert.equals(JSON.parse(body).PhysicalResourceId, '2017-03-02T08:00:00.000Z', 'PhysicalResourceId is stream label'); 
+      assert.equals(JSON.parse(body).PhysicalResourceId, '2017-03-02T05:00:00.000Z', 'PhysicalResourceId is stream label');
       AWS.DynamoDB.restore();
       assert.end();
     }


### PR DESCRIPTION
I noticed that there are a few tests failing in the `master` branch. Having travis-ci run tests for us automatically on every PR is a great way to protect against this.

Aside from the changes here, I also had to flip a switch for this repository in the UI at travis-ci.org.

cc @kellyoung 