### PR TITLE
Remove unneeded Fn::Joins

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -4,7 +4,7 @@ const cf = require('@mapbox/cloudfriend');
 module.exports.build = build;
 function build(params) {
   const functions = new Set(['SnsSubscription', 'DynamoDBStreamLabel', 'StackOutputs', 'SpotFleet']);
-  
+
   if(!params.CustomResourceName)
     throw new Error('Missing CustomResourceName');
   if (!functions.has(params.CustomResourceName))
@@ -206,8 +206,8 @@ function build(params) {
       }
     }
   };
-  CustomResource[params.LogicalName + 'Role'] = roles[params.CustomResourceName];
-  CustomResource[params.LogicalName + 'Function'] = {
+  CustomResource[`${params.LogicalName}Role`] = roles[params.CustomResourceName];
+  CustomResource[`${params.LogicalName}Function`] = {
     Type: 'AWS::Lambda::Function',
     // #### Properties
     Properties: {
@@ -215,13 +215,13 @@ function build(params) {
       // to S3, and refer to it here.
       Code: {
         S3Bucket: params.S3Bucket,
-        S3Key: params.S3Key 
+        S3Key: params.S3Key
       },
       // - Role: Refers to the ARN of the Role defined above.
-      Role: cf.getAtt(cf.join([params.LogicalName, 'Role']), 'Arn'),
+      Role: cf.getAtt(`${params.LogicalName}Role`, 'Arn'),
       // - Other parameters as described by
       // [the AWS documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html).
-      Description: cf.join(['Manages', params.CustomResourceName]) ,
+      Description: `Manages ${params.CustomResourceName}`,
       Handler: params.Handler,
       MemorySize: 128,
       Runtime: 'nodejs6.10',
@@ -230,13 +230,8 @@ function build(params) {
   };
   CustomResource[params.LogicalName] = {
     Type: 'Custom::MagicCfnResource',
-    Properties: Object.assign({ ServiceToken: cf.getAtt(cf.join([params.LogicalName, 'Function']), 'Arn')}, params.Properties)
+    Properties: Object.assign({ ServiceToken: cf.getAtt(`${params.LogicalName}Role`, 'Arn')}, params.Properties)
   };
 
   return { Resources: CustomResource };
 }
-    
-    
-    
-    
-  


### PR DESCRIPTION
When using this downstream, I was encountering errors saying that there were invalid calls to `Fn::GetAtt` when I tried to deploy the template.

Since JS-land knows the options that have been provided for the LogicalName, you can use JS to build the complete names, rather than using CFN's functions to put the strings together. I think that the source of the issue was that for the first argument of `Fn::GetAtt`, you cannot use another CFN intrinsic function -- you have to use a straight-up string. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html#w2ab2c21c28c27c13

