### PR TITLE
breaking out role resources

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -193,11 +193,21 @@ function build(params) {
                   Effect: 'Allow',
                   Action: [
                     'ec2:*',
-                    'iam:PassRole',
-                    'iam:ListRoles',
-                    'iam:ListInstanceProfiles'
                   ],
                   Resource: '*'
+                },
+                {
+                  Effect: 'Allow',
+                  Action: [
+                    'iam:ListRoles',
+                    'iam:PassRole'
+                  ],
+                  Resource: params.Properties.SpotFleetRequestConfigData.IamFleetRole
+                },
+                {
+                  Effect: 'Allow',
+                  Action: ['iam:ListInstanceProfiles'],
+                  Resource: params.Properties.SpotFleetRequestConfigData.InstanceProfile
                 }
               ]
             }

--- a/lib/build.js
+++ b/lib/build.js
@@ -205,7 +205,7 @@ function build(params) {
                 {
                   Effect: 'Allow',
                   Action: ['iam:ListInstanceProfiles'],
-                  Resource: params.Properties.SpotFleetRequestConfigData.InstanceProfile
+                  Resource: params.InstanceProfile
                 }
               ]
             }

--- a/lib/build.js
+++ b/lib/build.js
@@ -191,9 +191,7 @@ function build(params) {
                 // The function is able to create and delete spot fleet requests
                 {
                   Effect: 'Allow',
-                  Action: [
-                    'ec2:*',
-                  ],
+                  Action: ['ec2:*'],
                   Resource: '*'
                 },
                 {

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ const SpotFleet = magicCfnResources.build({
   Handler: 'spot-fleet.SpotFleet', // references the handler created in the repository
   Properties: {
     SpotFleetRequestConfigData: { }, // object with SpotFleet configuration specifics
-    SpotFleetRegion: 'region', // region of the SpotFleet i.e.: 'us-east-1'
+    Region: 'region', // region of the SpotFleet i.e.: 'us-east-1'
   }
 });
 ```


### PR DESCRIPTION
First shot at starting to limit the resources when creating a spotfleet as part of the quest for native spotfleet [tagging](https://github.com/mapbox/ecs-cluster/pull/480)

cc: @jakepruitt @rclark @kellyoung 