### PR TITLE
cloudfriend is not a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@mapbox/cloudfriend/-/cloudfriend-1.8.2.tgz",
       "integrity": "sha1-5ycHnqF70lu74wkVNnQsMP/TZ/4=",
-      "dev": true,
       "requires": {
         "aws-sdk": "2.95.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   "homepage": "https://github.com/mapbox/magic-cfn-resources#readme",
   "devDependencies": {
     "@mapbox/mock-aws-sdk-js": "0.0.5",
-    "@mapbox/cloudfriend": "^1.8.1",
     "documentation": "^1.4.0",
     "eslint": "^1.4.1",
     "tape": "^4.0.0"
   },
   "dependencies": {
+    "@mapbox/cloudfriend": "^1.8.1",
     "aws-sdk": "^2.1.35"
   }
 }


### PR DESCRIPTION
Because `@mapbox/cloudfriend` is used through `index.js` --> `.build()`, its not a development dependency. 

Prior to this PR, an attempt to run magic-cfn-resources after an `npm install --production` would fail.

cc @brendanmcfarland @taraadiseshan 