### PR TITLE
Adjusting Type to Custom::CustomResourceName

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -249,7 +249,7 @@ function build(params) {
     }
   };
   CustomResource[params.LogicalName] = {
-    Type: 'Custom::MagicCfnResource',
+    Type: cf.join('',['Custom::',params.CustomResourceName]),
     Properties: Object.assign({ ServiceToken: cf.getAtt(`${params.LogicalName}Function`, 'Arn')}, params.Properties)
   };
 

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -226,6 +226,6 @@ test('[build] success with Conditional', assert => {
   assert.equals(template.Resources.SpotFleetLogicalNameRole.Condition, 'Conditional', 'Conditional in Role');
   assert.equals(template.Resources.SpotFleetLogicalNameFunction.Condition, 'Conditional', 'Conditional in Function');
   assert.equals(template.Resources.SpotFleetLogicalName.Condition, 'Conditional', 'Conditional in Custom Resource');
-  assert.deepEqual(template.Resources.SpotFleetLogicalName.Type, { 'Fn::Join': [ '', [ 'Custom::', 'SpotFleet' ] ] }, 'Type equals Custom::params.CustomResourceName');  
+  assert.deepEqual(template.Resources.SpotFleetLogicalName.Type, { 'Fn::Join': [ '', [ 'Custom::', params.CustomResourceName ] ] }, 'Type equals Custom::params.CustomResourceName');  
   assert.end();
 })

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -205,7 +205,7 @@ test('[build] success', assert => {
 });
 
 test('[build] success with Conditional', assert => {
-  const template =  build({
+  var params = {
     CustomResourceName: 'SpotFleet',
     LogicalName: 'SpotFleetLogicalName',
     S3Key: 'lambda/code',
@@ -221,9 +221,11 @@ test('[build] success with Conditional', assert => {
       SpotFleetRegion: 'region'
     },
     Condition: 'Conditional'
-  });
+  };
+  const template =  build(params);
   assert.equals(template.Resources.SpotFleetLogicalNameRole.Condition, 'Conditional', 'Conditional in Role');
   assert.equals(template.Resources.SpotFleetLogicalNameFunction.Condition, 'Conditional', 'Conditional in Function');
   assert.equals(template.Resources.SpotFleetLogicalName.Condition, 'Conditional', 'Conditional in Custom Resource');
+  assert.deepEqual(template.Resources.SpotFleetLogicalName.Type, { 'Fn::Join': [ '', [ 'Custom::', 'SpotFleet' ] ] }, 'Type equals Custom::params.CustomResourceName');  
   assert.end();
 })


### PR DESCRIPTION
Per chat yesterday with @rclark @jakepruitt @kellyoung - I think this is all we'll need to change to get control over the resource Type naming.