### PR TITLE
Make aws arn's china-safe

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -113,7 +113,7 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: ['logs:*'],
-                  Resource: 'arn:aws:logs:*:*:*'
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
                 },
                 // The function is able to create and delete subscriptions
                 // for all SNS topics.
@@ -160,7 +160,7 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: ['logs:*'],
-                  Resource: 'arn:aws:logs:*:*:*'
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
                 },
                 // The function is able to describe DynamoDB tables
                 {
@@ -206,7 +206,7 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: ['logs:*'],
-                  Resource: 'arn:aws:logs:*:*:*'
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
                 },
                 // The function can describe stacks
                 {
@@ -251,7 +251,7 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: ['logs:*'],
-                  Resource: 'arn:aws:logs:*:*:*'
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
                 },
                 // it can getBucketNotification and putBucketNotification on any s3 bucket
                 {
@@ -295,7 +295,7 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: ['logs:*'],
-                  Resource: 'arn:aws:logs:*:*:*'
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
                 },
                 // The function is able to create and delete spot fleet requests
                 {
@@ -344,7 +344,7 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: ['logs:*'],
-                  Resource: 'arn:aws:logs:*:*:*'
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
                 },
                 {
                   Effect: 'Allow',
@@ -383,7 +383,7 @@ function moreResources(params, customResource) {
               Action: 'SNS:Publish',
               Resource: params.Properties.SnsTopicArn,
               Condition: {
-                ArnLike: { 'aws:SourceArn': `arn:aws:s3:::${params.Properties.Bucket}` }
+                ArnLike: { 'aws:SourceArn': cf.sub('arn:${AWS::Partition}:s3:::${bucket}', { bucket: params.Properties.Bucket }) }
               }
             }
           ]


### PR DESCRIPTION
Adds the `${AWS::Partition}` instead of `:aws:` in ARN's.

cc/ @kellyoung @rclark 