### PR TITLE
default-vpc PublicSubnets should export only public subnets

### DIFF
--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -22,7 +22,7 @@ module.exports = function(event, context) {
       ec2.describeRouteTables({ Filters: [{ Name: 'vpc-id', Values: [info.VpcId] }] }).promise()
     ]);
   }).then((results) => {
-    var publicSubnets = results[0].Subnets.filter((subnet) => subnet.MapPublicIpOnLaunch);
+    let publicSubnets = results[0].Subnets.filter((subnet) => subnet.MapPublicIpOnLaunch);
 
     info.AvailabilityZones = publicSubnets.map((subnet) => subnet.AvailabilityZone);
     info.AvailabilityZoneCount = publicSubnets.length;

--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -22,9 +22,11 @@ module.exports = function(event, context) {
       ec2.describeRouteTables({ Filters: [{ Name: 'vpc-id', Values: [info.VpcId] }] }).promise()
     ]);
   }).then((results) => {
-    info.AvailabilityZones = results[0].Subnets.map((subnet) => subnet.AvailabilityZone);
-    info.AvailabilityZoneCount = results[0].Subnets.length;
-    info.PublicSubnets = results[0].Subnets.map((subnet) => subnet.SubnetId);
+    var publicSubnets = results[0].Subnets.filter((subnet) => subnet.MapPublicIpOnLaunch);
+
+    info.AvailabilityZones = publicSubnets.map((subnet) => subnet.AvailabilityZone);
+    info.AvailabilityZoneCount = publicSubnets.length;
+    info.PublicSubnets = publicSubnets.map((subnet) => subnet.SubnetId);
     info.RouteTable = results[1].RouteTables[0].RouteTableId;
     response.setId(info.VpcId);
     response.send(null, info);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/magic-cfn-resources",
-  "version": "1.5.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,16 +20,6 @@
       "requires": {
         "aws-sdk": "2.95.0",
         "traverse": "0.6.6"
-      }
-    },
-    "JSONStream": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
-      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
       }
     },
     "acorn": {
@@ -457,7 +447,6 @@
       "integrity": "sha1-iF+e5Fd0BdFnVaiB4io7C+Xpt0Q=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.10.0",
         "ast-types": "0.7.8",
         "concat-stream": "1.6.0",
         "doctrine": "0.6.4",
@@ -470,6 +459,7 @@
         "hat": "0.0.3",
         "highlight.js": "8.9.1",
         "jsdoc-inline-lex": "1.0.1",
+        "JSONStream": "0.10.0",
         "map-stream": "0.0.5",
         "micromatch": "2.3.11",
         "module-deps": "3.9.1",
@@ -1710,6 +1700,16 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
+    },
     "just-extend": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
@@ -2136,13 +2136,13 @@
       "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "concat-stream": "1.4.10",
         "defined": "1.0.0",
         "detective": "4.5.0",
         "duplexer2": "0.0.2",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "1.1.14",
         "resolve": "1.4.0",
@@ -2152,16 +2152,6 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
-        },
         "concat-stream": {
           "version": "1.4.10",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
@@ -2184,6 +2174,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
         },
         "readable-stream": {
           "version": "1.1.14",
@@ -3930,6 +3930,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3950,15 +3959,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.0",
         "function-bind": "1.1.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/magic-cfn-resources",
-  "version": "1.3.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,6 +20,16 @@
       "requires": {
         "aws-sdk": "2.95.0",
         "traverse": "0.6.6"
+      }
+    },
+    "JSONStream": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
       }
     },
     "acorn": {
@@ -447,6 +457,7 @@
       "integrity": "sha1-iF+e5Fd0BdFnVaiB4io7C+Xpt0Q=",
       "dev": true,
       "requires": {
+        "JSONStream": "0.10.0",
         "ast-types": "0.7.8",
         "concat-stream": "1.6.0",
         "doctrine": "0.6.4",
@@ -459,7 +470,6 @@
         "hat": "0.0.3",
         "highlight.js": "8.9.1",
         "jsdoc-inline-lex": "1.0.1",
-        "JSONStream": "0.10.0",
         "map-stream": "0.0.5",
         "micromatch": "2.3.11",
         "module-deps": "3.9.1",
@@ -1700,16 +1710,6 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
-      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
-    },
     "just-extend": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
@@ -2136,13 +2136,13 @@
       "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "concat-stream": "1.4.10",
         "defined": "1.0.0",
         "detective": "4.5.0",
         "duplexer2": "0.0.2",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "1.1.14",
         "resolve": "1.4.0",
@@ -2152,6 +2152,16 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
+        },
         "concat-stream": {
           "version": "1.4.10",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
@@ -2174,16 +2184,6 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
         },
         "readable-stream": {
           "version": "1.1.14",
@@ -3930,15 +3930,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3959,6 +3950,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/test/default-vpc.test.js
+++ b/test/default-vpc.test.js
@@ -26,8 +26,9 @@ test('[default VPC] success', (assert) => {
   AWS.stub('EC2', 'describeSubnets', function() {
     this.request.promise.returns(Promise.resolve({
       Subnets: [
-        { SubnetId: 'a', AvailabilityZone: '1a' },
-        { SubnetId: 'b', AvailabilityZone: '1b' }
+        { SubnetId: 'a', AvailabilityZone: '1a', MapPublicIpOnLaunch: true },
+        { SubnetId: 'b', AvailabilityZone: '1b', MapPublicIpOnLaunch: true },
+        { SubnetId: 'c', AvailabilityZone: '1c', MapPublicIpOnLaunch: false }
       ]
     }));
   });


### PR DESCRIPTION
For context: https://github.com/mapbox/ecs-corecache/issues/46#issuecomment-376560861

This allows users to attach custom private subnets to the default VPC without affecting other users. 