### PR TITLE
S3Inventory

### DIFF
--- a/functions/s3-inventory.js
+++ b/functions/s3-inventory.js
@@ -43,6 +43,8 @@ S3Inventory.manage = function(event, context, callback) {
     return response.send(err);
   }
 
+  console.log(`${requestType} ${event.ResourceProperties.Bucket}:${event.ResourceProperties.Id}`);
+
   s3Inventory[requestType](function(err, physicalId) {
     if (err) return response.send(err);
     if (physicalId) response.setId(physicalId);
@@ -51,9 +53,13 @@ S3Inventory.manage = function(event, context, callback) {
 }
 
 S3Inventory.prototype.create = function(callback) {
+  const bucket = this.params.Bucket;
   const id = this.params.Id;
   this.s3.putBucketInventoryConfiguration(this.params, function(err) {
     if (err) console.log(err);
+
+    console.log(`created ${bucket}:${id}`);
+
     callback(null, id);
   });
 };
@@ -72,6 +78,9 @@ S3Inventory.prototype.update = function(callback) {
       Id: old
     }, function (err) {
       if (err) console.log(err);
+
+      console.log(`deleted ${bucket}:${old}`);
+
       callback(null, id);
     });
 
@@ -79,11 +88,17 @@ S3Inventory.prototype.update = function(callback) {
 };
 
 S3Inventory.prototype.delete = function(callback) {
+  const bucket = this.params.Bucket;
+  const id = this.params.Id;
+
   this.s3.deleteBucketInventoryConfiguration({
-    Bucket: this.params.Bucket,
-    Id: this.params.Id
+    Bucket: bucket,
+    Id: id
   }, function(err) {
     if (err) console.log(err);
+
+    console.log(`deleted ${bucket}:${id}`);
+
     callback();
   });
 };

--- a/functions/s3-inventory.js
+++ b/functions/s3-inventory.js
@@ -1,0 +1,86 @@
+var AWS = require('aws-sdk');
+var utils = require('../lib/utils');
+var Response = require('../lib/response');
+
+module.exports = S3Inventory;
+
+function S3Inventory(Bucket, BucketRegion, Id, InventoryConfiguration, OldId) {
+  if (!Bucket)
+    throw new Error('Missing Parameter Bucket');
+  if (!BucketRegion)
+    throw new Error('Missing Parameter BucketRegion');
+  if (!Id)
+    throw new Error('Missing Parameter Id');
+  if (!InventoryConfiguration)
+    throw new Error('Missing Parameter InventoryConfiguration');
+
+  this.s3 = new AWS.S3({ region: BucketRegion });
+  this.params = { Bucket, Id, InventoryConfiguration };
+
+  if (OldId !== Id) this.oldId = OldId;
+}
+
+S3Inventory.manage = function(event, context, callback) {
+  if (!utils.validCloudFormationEvent(event))
+    return callback(null, 'ERROR: Invalid CloudFormation event');
+
+  var response = new Response(event, context);
+  var requestType = event.RequestType.toLowerCase();
+
+  var s3Inventory;
+  try {
+    s3Inventory = new S3Inventory(
+      event.ResourceProperties.Bucket,
+      event.ResourceProperties.BucketRegion,
+      event.ResourceProperties.Id,
+      event.ResourceProperties.InventoryConfiguration,
+      event.OldResourceProperties ? event.OldResourceProperties.Id : undefined
+    );
+  } catch (err) {
+    return response.send(err);
+  }
+
+  s3Inventory[requestType](function(err, physicalId) {
+    if (err) return response.send(err);
+    if (physicalId) response.setId(physicalId);
+    response.send();
+  });
+}
+
+S3Inventory.prototype.create = function(callback) {
+  const id = this.params.Id;
+  this.s3.putBucketInventoryConfiguration(this.params, function(err) {
+    if (err) return callback(err);
+    callback(null, id);
+  });
+};
+
+S3Inventory.prototype.update = function(callback) {
+  var old = this.oldId;
+  var s3 = this.s3;
+  var bucket = this.params.Bucket;
+
+  this.create(function(err, id) {
+    if (err) return callback(err);
+    if (!old) return callback(null, id);
+
+    s3.deleteBucketInventoryConfiguration({
+      Bucket: bucket,
+      Id: old
+    }, function (err) {
+      if (err) return callback(err);
+      callback(null, id);
+    });
+
+  })
+};
+
+S3Inventory.prototype.delete = function(callback) {
+  this.s3.deleteBucketInventoryConfiguration({
+    Bucket: this.params.Bucket,
+    Id: this.params.Id
+  }, function(err) {
+    if (err) return callback(err);
+    callback();
+  });
+};

--- a/functions/s3-inventory.js
+++ b/functions/s3-inventory.js
@@ -50,7 +50,7 @@ S3Inventory.manage = function(event, context, callback) {
 S3Inventory.prototype.create = function(callback) {
   const id = this.params.Id;
   this.s3.putBucketInventoryConfiguration(this.params, function(err) {
-    if (err) return callback(err);
+    if (err) console.log(err);
     callback(null, id);
   });
 };
@@ -68,7 +68,7 @@ S3Inventory.prototype.update = function(callback) {
       Bucket: bucket,
       Id: old
     }, function (err) {
-      if (err) return callback(err);
+      if (err) console.log(err);
       callback(null, id);
     });
 
@@ -80,7 +80,7 @@ S3Inventory.prototype.delete = function(callback) {
     Bucket: this.params.Bucket,
     Id: this.params.Id
   }, function(err) {
-    if (err) return callback(err);
+    if (err) console.log(err);
     callback();
   });
 };

--- a/functions/s3-inventory.js
+++ b/functions/s3-inventory.js
@@ -56,7 +56,7 @@ S3Inventory.prototype.create = function(callback) {
   const bucket = this.params.Bucket;
   const id = this.params.Id;
   this.s3.putBucketInventoryConfiguration(this.params, function(err) {
-    if (err) console.log(err);
+    if (err) return callback(err);
 
     console.log(`created ${bucket}:${id}`);
 
@@ -77,7 +77,7 @@ S3Inventory.prototype.update = function(callback) {
       Bucket: bucket,
       Id: old
     }, function (err) {
-      if (err) console.log(err);
+      if (err) return callback(err);
 
       console.log(`deleted ${bucket}:${old}`);
 
@@ -95,7 +95,7 @@ S3Inventory.prototype.delete = function(callback) {
     Bucket: bucket,
     Id: id
   }, function(err) {
-    if (err) console.log(err);
+    if (err) return callback(err);
 
     console.log(`deleted ${bucket}:${id}`);
 

--- a/functions/s3-inventory.js
+++ b/functions/s3-inventory.js
@@ -14,6 +14,9 @@ function S3Inventory(Bucket, BucketRegion, Id, InventoryConfiguration, OldId) {
   if (!InventoryConfiguration)
     throw new Error('Missing Parameter InventoryConfiguration');
 
+  InventoryConfiguration.IsEnabled = InventoryConfiguration.IsEnabled === 'true'
+    ? true : false;
+
   this.s3 = new AWS.S3({ region: BucketRegion });
   this.params = { Bucket, Id, InventoryConfiguration };
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports.StackOutputs = require('./functions/stack-outputs').manage;
 module.exports.SpotFleet = require('./functions/spot-fleet').manage;
 module.exports.S3NotificationTopicConfig = require('./functions/s3-notification-topic-config').manage;
 module.exports.DefaultVpc = require('./functions/default-vpc');
+module.exports.S3Inventory = require('./functions/s3-inventory').manage;
 
 module.exports.helpers = {
   Response: require('./lib/response'),

--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,8 @@ function build(params) {
     'StackOutputs',
     'SpotFleet',
     'DefaultVpc',
-    'S3NotificationTopicConfig'
+    'S3NotificationTopicConfig',
+    'S3Inventory'
   ]);
 
   if(!params.CustomResourceName)
@@ -361,6 +362,43 @@ function role(params) {
         ]
       }
     };
+  case 'S3Inventory':
+    return {
+      Type: 'AWS::IAM::Role',
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: { Service: 'lambda.amazonaws.com' },
+              Action: 'sts:AssumeRole'
+            }
+          ]
+        },
+        Policies: [
+          {
+            PolicyName: 'S3InventoryPolicy',
+            PolicyDocument: {
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Action: ['logs:*'],
+                  Resource: cf.sub('arn:${AWS::Partition}:logs:*:*:*')
+                },
+                {
+                  Effect: 'Allow',
+                  Action: [
+                    's3:PutBucketInventoryConfiguration',
+                    's3:DeleteBucketInventoryConfiguration'
+                  ],
+                  Resource: '*'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
   default:
     throw new Error('Unknown resource name');
   }

--- a/lib/build.js
+++ b/lib/build.js
@@ -388,8 +388,8 @@ function role(params) {
                 {
                   Effect: 'Allow',
                   Action: [
-                    's3:PutBucketInventoryConfiguration',
-                    's3:DeleteBucketInventoryConfiguration'
+                    's3:PutInventoryConfiguration',
+                    's3:DeleteInventoryConfiguration'
                   ],
                   Resource: '*'
                 }

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,10 @@ You can use `Fn::GetAtt` to obtain the following data:
 
 Creates a notification topic configuration on an S3 bucket.
 
+### S3Inventory
+
+Creates an [InventoryConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-inventoryconfiguration.html) for **an existing** S3 bucket that is not defined in CloudFormation. If you are defining an S3 bucket in CloudFormation, you can use the native CloudFormation support for this configuration.
+
 ## To create a magical resource in your own CloudFormation template:
 #### In an existing script or in a new script (i.e. `sns-subscription.js`):
 ```js
@@ -165,6 +169,36 @@ const S3TopicConfig = magicCfnResources.build({
     BucketNotificationResources: [ 'bucket Arn' ] 
     // if Bucket permissions need to be scoped, default is access to all resources (optional)
   } 
+});
+```
+
+*S3Inventory*
+
+```js
+const S3InventoryConfig = magic.build({
+  CustomResourceName: 'S3Inventory',
+  LogicalName: 'Logical Name', // a name to refer to the custom resource being built
+  S3Bucket: 'Bucket Name', // the S3 bucket the code for the handler lives in
+  S3Key: 'Key', // the S3 key for where the handler lives
+  Handler: 'index.S3Inventory', // references the handler created in the repository
+  Properties: { // Properties here are identical to those in the CloudFormation-native InventoryConfiguration
+    BucketRegion: 'us-east-1', // the only additional property required
+    Bucket: 'my-bucket',
+    Id: 'my-inventory-id',
+    InventoryConfiguration: {
+      Schedule: { Frequency: 'Daily' },
+      IsEnabled: true,
+      Destination: {
+        S3BucketDestination: {
+          Bucket: cf.getAtt('my-inventory-bucket', 'Arn'),
+          Format: 'ORC'
+        }
+      },
+      OptionalFields: ['Size', 'LastModifiedDate', 'EncryptionStatus'],
+      IncludedObjectVersions: 'Current',
+      Id: 'my-inventory-id'
+    }
+  }
 });
 ```
 

--- a/test/s3-inventory.test.js
+++ b/test/s3-inventory.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const S3Inventory = require('../functions/s3-inventory');
+const test = require('tape');
+const AWS = require('@mapbox/mock-aws-sdk-js');
+
+test('[s3-inventory] constructor', (assert) => {
+  assert.throws(() => new S3Inventory(), /Missing Parameter/, 'throws with no bucket');
+  assert.throws(() => new S3Inventory('bucket'), /Missing Parameter/, 'throws with no region');
+  assert.throws(() => new S3Inventory('bucket', 'us-east-1'), /Missing Parameter/, 'throws with no id');
+  assert.throws(() => new S3Inventory('bucket', 'us-east-1', 'id'), /Missing Parameter/, 'throws with no config');
+
+  AWS.stub('S3', 'getObject');
+
+  const newInv = new S3Inventory('bucket', 'us-east-1', 'id', {});
+  const updateInv = new S3Inventory('bucket', 'us-east-1', 'id', {}, 'old');
+  const updateSame = new S3Inventory('bucket', 'us-east-1', 'id', {}, 'id');
+
+  assert.ok(AWS.S3.calledWith({ region: 'us-east-1' }), 'created s3 client in the right region');
+  assert.deepEqual(newInv.params, {
+    Bucket: 'bucket',
+    Id: 'id',
+    InventoryConfiguration: {}
+  }, 'sets properties for create');
+
+  assert.equal(updateInv.oldId, 'old', 'update sets oldId property when intention is to create a new inventory');
+  assert.notOk(updateSame.oldId, 'no oldId set when updating an inventory in place');
+
+  AWS.S3.restore();
+  assert.end();
+});
+
+test('[s3-inventory] create', (assert) => {
+  const put = AWS.stub('S3', 'putBucketInventoryConfiguration').yields();
+  const newInv = new S3Inventory('bucket', 'us-east-1', 'id', {});
+
+  newInv.create((err, id) => {
+    assert.ifError(err, 'test failed');
+
+    assert.equal(id, 'id', 'returns id');
+
+    assert.ok(put.calledWith({
+      Bucket: 'bucket', Id: 'id', InventoryConfiguration: {}
+    }), 'called API with expected parameters');
+
+    AWS.S3.restore();
+    assert.end();
+  });
+});
+
+test('[s3-inventory] update', (assert) => {
+  const put = AWS.stub('S3', 'putBucketInventoryConfiguration').yields();
+  const del = AWS.stub('S3', 'deleteBucketInventoryConfiguration').yields();
+  const updateInv = new S3Inventory('bucket', 'us-east-1', 'id', {}, 'old');
+
+  updateInv.update((err, id) => {
+    assert.ifError(err, 'test failed');
+
+    assert.equal(id, 'id', 'returns new id');
+
+    assert.ok(put.calledWith({
+      Bucket: 'bucket', Id: 'id', InventoryConfiguration: {}
+    }), 'called put API with expected parameters');
+
+    assert.ok(del.calledWith({
+      Bucket: 'bucket', Id: 'old'
+    }), 'called delete API with expected parameters');
+
+    AWS.S3.restore();
+    assert.end();
+  });
+});
+
+test('[s3-inventory] delete', (assert) => {
+  const del = AWS.stub('S3', 'deleteBucketInventoryConfiguration').yields();
+  const delInv = new S3Inventory('bucket', 'us-east-1', 'id', {}, 'id');
+
+  delInv.delete((err) => {
+    assert.ifError(err, 'test failed');
+
+    assert.ok(del.calledWith({
+      Bucket: 'bucket', Id: 'id'
+    }), 'called delete API with expected parameters');
+
+    AWS.S3.restore();
+    assert.end();
+  });
+});

--- a/test/s3-inventory.test.js
+++ b/test/s3-inventory.test.js
@@ -20,7 +20,7 @@ test('[s3-inventory] constructor', (assert) => {
   assert.deepEqual(newInv.params, {
     Bucket: 'bucket',
     Id: 'id',
-    InventoryConfiguration: {}
+    InventoryConfiguration: { IsEnabled: false }
   }, 'sets properties for create');
 
   assert.equal(updateInv.oldId, 'old', 'update sets oldId property when intention is to create a new inventory');
@@ -40,7 +40,7 @@ test('[s3-inventory] create', (assert) => {
     assert.equal(id, 'id', 'returns id');
 
     assert.ok(put.calledWith({
-      Bucket: 'bucket', Id: 'id', InventoryConfiguration: {}
+      Bucket: 'bucket', Id: 'id', InventoryConfiguration: { IsEnabled: false }
     }), 'called API with expected parameters');
 
     AWS.S3.restore();
@@ -59,7 +59,7 @@ test('[s3-inventory] update', (assert) => {
     assert.equal(id, 'id', 'returns new id');
 
     assert.ok(put.calledWith({
-      Bucket: 'bucket', Id: 'id', InventoryConfiguration: {}
+      Bucket: 'bucket', Id: 'id', InventoryConfiguration: { IsEnabled: false }
     }), 'called put API with expected parameters');
 
     assert.ok(del.calledWith({


### PR DESCRIPTION
This PR adds a new magic resource that creates an [S3 inventory configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html) for a bucket that you specify.

There actually [is native support in CloudFormation for this](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-inventoryconfiguration.html), but only if the bucket that you want to inventory is defined in CloudFormation -- this support is a sub-property of an `AWS::S3::Bucket`.

This magic resource would allow you to add an inventory configuration to some already-existing bucket.