### PR TITLE
Expose array of private subnets via DefaultVpc

### DIFF
--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -9,7 +9,7 @@ module.exports = function(event, context) {
 
   var requestType = event.RequestType.toLowerCase();
   if (requestType === 'delete') return response.send();
-  
+
   var ec2 = new AWS.EC2();
   var info = {};
 
@@ -23,10 +23,12 @@ module.exports = function(event, context) {
     ]);
   }).then((results) => {
     var publicSubnets = results[0].Subnets.filter((subnet) => subnet.MapPublicIpOnLaunch);
+    var privateSubnets = results[0].Subnets.filter((subnet) => !subnet.MapPublicIpOnLaunch);
 
     info.AvailabilityZones = publicSubnets.map((subnet) => subnet.AvailabilityZone);
     info.AvailabilityZoneCount = publicSubnets.length;
     info.PublicSubnets = publicSubnets.map((subnet) => subnet.SubnetId);
+    info.PrivateSubnets = privateSubnets.map((subnet) => subnet.SubnetId);
     info.RouteTable = results[1].RouteTables[0].RouteTableId;
     response.setId(info.VpcId);
     response.send(null, info);

--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -27,6 +27,8 @@ module.exports = function(event, context) {
 
     info.AvailabilityZones = publicSubnets.map((subnet) => subnet.AvailabilityZone);
     info.AvailabilityZoneCount = publicSubnets.length;
+    info.PrivateSubnetAvailabilityZones = privateSubnets.map((subnet) => subnet.AvailabilityZone);
+    info.PrivateSubnetAvailabilityZoneCount = privateSubnets.length;
     info.PublicSubnets = publicSubnets.map((subnet) => subnet.SubnetId);
     info.PrivateSubnets = privateSubnets.map((subnet) => subnet.SubnetId);
     info.RouteTable = results[1].RouteTables[0].RouteTableId;

--- a/test/default-vpc.test.js
+++ b/test/default-vpc.test.js
@@ -51,6 +51,8 @@ test('[default VPC] success', (assert) => {
       VpcId: 'vpcid',
       AvailabilityZones: ['1a','1b'],
       AvailabilityZoneCount: 2,
+      PrivateSubnetAvailabilityZones: ['1c'],
+      PrivateSubnetAvailabilityZoneCount: 1,
       PublicSubnets: ['a', 'b'],
       PrivateSubnets: ['c'],
       RouteTable: 'a'

--- a/test/default-vpc.test.js
+++ b/test/default-vpc.test.js
@@ -52,6 +52,7 @@ test('[default VPC] success', (assert) => {
       AvailabilityZones: ['1a','1b'],
       AvailabilityZoneCount: 2,
       PublicSubnets: ['a', 'b'],
+      PrivateSubnets: ['c'],
       RouteTable: 'a'
     }, 'returns expected info');
 


### PR DESCRIPTION
This PR adds an array of private subnets to the properties of the DefaultVpc custom resource. This allows the caller to look up both public and private subnets in the default vpc.