### PR TITLE
AZ-indexed subnets

### DIFF
--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -36,6 +36,12 @@ module.exports = function(event, context) {
       else return { Ref: 'AWS::NoValue' }
     });
 
+    info.AzIndexedPublicSubnets = ['a', 'b', 'c', 'd', 'e', 'f'].map((letter) => {
+      const subnet = publicSubnets.find((s) => s.AvailabilityZone.slice(-1) === letter);
+      if (subnet) return subnet.SubnetId;
+      else return { Ref: 'AWS::NoValue' }
+    });
+
     info.PublicSubnets = publicSubnets.map((subnet) => subnet.SubnetId);
     info.PrivateSubnets = privateSubnets.map((subnet) => subnet.SubnetId);
     info.RouteTable = results[1].RouteTables[0].RouteTableId;

--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -29,6 +29,13 @@ module.exports = function(event, context) {
     info.AvailabilityZoneCount = publicSubnets.length;
     info.PrivateSubnetAvailabilityZones = privateSubnets.map((subnet) => subnet.AvailabilityZone);
     info.PrivateSubnetAvailabilityZoneCount = privateSubnets.length;
+
+    info.AzIndexedPrivateSubnets = ['a', 'b', 'c', 'd', 'e', 'f'].map((letter) => {
+      const subnet = privateSubnets.find((s) => s.AvailabilityZone.slice(-1) === letter);
+      if (subnet) return subnet.SubnetId;
+      else return { Ref: 'AWS::NoValue' }
+    });
+
     info.PublicSubnets = publicSubnets.map((subnet) => subnet.SubnetId);
     info.PrivateSubnets = privateSubnets.map((subnet) => subnet.SubnetId);
     info.RouteTable = results[1].RouteTables[0].RouteTableId;

--- a/test/default-vpc.test.js
+++ b/test/default-vpc.test.js
@@ -53,6 +53,7 @@ test('[default VPC] success', (assert) => {
       AvailabilityZoneCount: 2,
       PrivateSubnetAvailabilityZones: ['1c'],
       PrivateSubnetAvailabilityZoneCount: 1,
+      AzIndexedPrivateSubnets: [{ Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, 'c', { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }],
       PublicSubnets: ['a', 'b'],
       PrivateSubnets: ['c'],
       RouteTable: 'a'

--- a/test/default-vpc.test.js
+++ b/test/default-vpc.test.js
@@ -53,6 +53,7 @@ test('[default VPC] success', (assert) => {
       AvailabilityZoneCount: 2,
       PrivateSubnetAvailabilityZones: ['1c'],
       PrivateSubnetAvailabilityZoneCount: 1,
+      AzIndexedPublicSubnets: ['a', 'b', { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }],
       AzIndexedPrivateSubnets: [{ Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, 'c', { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }],
       PublicSubnets: ['a', 'b'],
       PrivateSubnets: ['c'],


### PR DESCRIPTION
Adds more default VPC output properties: `AzIndexedPrivateSubnets` and `AzIndexedPublicSubnets`. These outputs are arrays that always have 6 entries, where each array index corresponds to a specific availability zone letter:

- `0`: the subnet id in availability zone `a`
- `1`: the subnet id in availability zone `b`
- `2`: the subnet id in availability zone `c`
- `3`: the subnet id in availability zone `d`
- `4`: the subnet id in availability zone `e`
- `5`: the subnet id in availability zone `f`

If there is no subnet in a given AZ, then the array value is `{ Ref: 'AWS::NoValue' }`.

This allows a caller to lookup the subnet in a requested availability zone. For example, if you want the private subnet in availability zone d:

```
{ "Fn::Select": [3, { "Fn::GetAtt": ["DefaultVpc", "AzIndexedPrivateSubnets"] }] }
```