### PR TITLE
update to node10x

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -64,7 +64,7 @@ function build(params) {
       Description: `Manages ${params.CustomResourceName}`,
       Handler: params.Handler,
       MemorySize: 128,
-      Runtime: 'nodejs6.10',
+      Runtime: 'nodejs10.x',
       Timeout: 30
     }
   };

--- a/test/dynamodb-stream-label.test.js
+++ b/test/dynamodb-stream-label.test.js
@@ -124,7 +124,7 @@ test('[dynamodb-stream-label] manage parses events and relays LatestStreamLabel 
   };
 
   DynamoDBStreamLabel.manage({
-    ResponseURL: 'http://aws.response.com/hello',
+    ResponseURL: 'https://api.mapbox.com/hello',
     PhysicalResourceId: 'abc',
     StackId: 'abc',
     LogicalResourceId: 'abc',

--- a/test/s3-notification-topic-config.test.js
+++ b/test/s3-notification-topic-config.test.js
@@ -15,7 +15,7 @@ test('[s3-notification-topic-config] create handles errors', assert => {
   AWS.stub('S3', 'putBucketNotificationConfiguration', (opts, cb) => {
     assert.ok(opts.hasOwnProperty('NotificationConfiguration'), 'should have NotificationConfiguration passed in call');
     return cb(new Error('random error'));
-  }); 
+  });
 
   const notificationConfig = new S3NotificationConfig('test-config', 'arn:aws:sns:us-east-1:special-topic', 'test-bucket', 'us-east-1', ['s3:objectCreated:*']);
 
@@ -38,7 +38,7 @@ test('[s3-notification-topic-config] create handles success', assert => {
   AWS.stub('S3', 'putBucketNotificationConfiguration', (opts, cb) => {
     assert.ok(opts.hasOwnProperty('NotificationConfiguration'), 'should have NotificationConfiguration passed in call');
     return cb(null, 'putBucket success');
-  }); 
+  });
 
   const notificationConfig = new S3NotificationConfig('test-config', 'arn:aws:sns:us-east-1:special-topic', 'test-bucket', 'us-east-1', ['s3:objectCreated:*']);
 
@@ -80,7 +80,7 @@ test('[s3-notification-topic-config] update deletes old topic config and creates
   const notificationConfig = new S3NotificationConfig(
     'test-config',
     'arn:aws:sns:us-east-1:special-topic',
-    'test-bucket', 
+    'test-bucket',
     'us-east-1',
     ['s3:objectCreated:*'],
     undefined,
@@ -117,7 +117,7 @@ test('[s3-notification-topic-config] delete removes the config', assert => {
     assert.ok(opts.hasOwnProperty('NotificationConfiguration'), 'should have NotificationConfiguration passed in call');
     assert.ok(opts.NotificationConfiguration.TopicConfigurations.length === 0, 'should not have any TopicConfigurations');
     return cb(null, 'putBucket success');
-  }); 
+  });
 
   const notificationConfig = new S3NotificationConfig('test-config', 'arn:aws:sns:us-east-1:special-topic', 'test-bucket', 'us-east-1', ['s3:objectCreated:*']);
 
@@ -154,10 +154,10 @@ test('[s3-notification-topic-config] manage parses events and relays LatestStrea
     assert.ok(opts.hasOwnProperty('NotificationConfiguration'), 'should have NotificationConfiguration passed in call');
     assert.ok(opts.NotificationConfiguration.TopicConfigurations.length === 1, 'should have a TopicConfiguration');
     return cb(null, 'putBucket success');
-  }); 
+  });
 
   S3NotificationConfig.manage({
-    ResponseURL: 'https://aws.response.com/hello',
+    ResponseURL: 'https://api.mapbox.com/hello',
     PhysicalResourceId: 'abc',
     StackId: 'abc',
     LogicalResourceId: 'abc',

--- a/test/sns-subscription.test.js
+++ b/test/sns-subscription.test.js
@@ -11,7 +11,7 @@ test('[sns-subscription] create handles errors', assert => {
       Endpoint: 'someone@mapbox.com'
     });
     return cb(new Error('random error'));
-  }); 
+  });
 
   const subscription = new SnsSubscription('arn:aws:sns:us-east-1:special-topic', 'email', 'someone@mapbox.com');
 
@@ -30,7 +30,7 @@ test('[sns-subscription] create handles success', assert => {
       Endpoint: 'someone@mapbox.com'
     });
     return cb();
-  }); 
+  });
 
   const subscription = new SnsSubscription('arn:aws:sns:us-east-1:special-topic', 'email', 'someone@mapbox.com');
 
@@ -50,14 +50,14 @@ test('[sns-subscription] update unsubscribes old endpoint and subscribes the new
       Endpoint: 'someone-new@mapbox.com'
     });
     return cb();
-  }); 
+  });
 
   const unsubscribe = AWS.stub('SNS', 'unsubscribe', (opts, cb) => {
     assert.deepEquals(opts, {
       SubscriptionArn: 'arn:aws:sns:us-east-1:special-subscription'
     });
     return cb();
-  }); 
+  });
 
   const listSubscriptionsByTopic = AWS.stub('SNS', 'listSubscriptionsByTopic')
     .onCall(0)
@@ -106,14 +106,14 @@ test('[sns-subscription] update still works when old subscription is not found',
       Endpoint: 'someone-new@mapbox.com'
     });
     return cb();
-  }); 
+  });
 
   const unsubscribe = AWS.stub('SNS', 'unsubscribe', (opts, cb) => {
     assert.deepEquals(opts, {
       SubscriptionArn: 'arn:aws:sns:us-east-1:special-subscription'
     });
     return cb();
-  }); 
+  });
 
   const listSubscriptionsByTopic = AWS.stub('SNS', 'listSubscriptionsByTopic', (opts, callback) => {
     assert.deepEquals(opts, { TopicArn: 'arn:aws:sns:us-east-1:special-topic' });
@@ -149,7 +149,7 @@ test('[sns-subscription] delete does same thing as update', assert => {
   });
 
   const listSubscriptionsByTopic = AWS.stub('SNS', 'listSubscriptionsByTopic', (opts, callback) => {
-    assert.deepEquals(opts, { TopicArn: 'arn:aws:sns:us-east-1:special-topic' }); 
+    assert.deepEquals(opts, { TopicArn: 'arn:aws:sns:us-east-1:special-topic' });
     return callback(null, {
       Subscriptions: [{
         Endpoint: 'the.wrong.email@mapbox.com',
@@ -188,10 +188,10 @@ test('[sns-subscription] manage parses events and relays LatestStreamLabel throu
       Endpoint: 'endpoint'
     });
     return cb();
-  }); 
+  });
 
   SnsSubscription.manage({
-    ResponseURL: 'http://aws.response.com/hello',
+    ResponseURL: 'http://api.mapbox.com/hello',
     PhysicalResourceId: 'abc',
     StackId: 'abc',
     LogicalResourceId: 'abc',

--- a/test/spot-fleet.test.js
+++ b/test/spot-fleet.test.js
@@ -23,7 +23,7 @@ test('[spot-fleet] create handles errors', assert => {
       DryRun: false
     }, 'requestSpotFleet parameters');
     return cb(new Error('random error'));
-  }); 
+  });
 
   const spotfleet = new SpotFleet({
     AllocationStrategy : 'diversified',
@@ -110,7 +110,7 @@ test('[spot-fleet] update updates the requestId, yields the requestId from _this
 
   const describeSpotFleetRequests = AWS.stub('EC2', 'describeSpotFleetRequests').yields(null, {
     SpotFleetRequestConfigs: [
-      { 
+      {
         SpotFleetRequestConfig: {
           TargetCapacity: 1
         }
@@ -127,7 +127,7 @@ test('[spot-fleet] update updates the requestId, yields the requestId from _this
     AWS.EC2.restore();
     assert.end();
   });
-    
+
 });
 
 test('[spot-fleet] delete cancels spot fleet request', (assert) => {
@@ -185,7 +185,7 @@ test('[spot-fleet] delete does nothing if request id not found', (assert) => {
 });
 
 test('[spot-fleet] manage parses events and relays LatestStreamLabel through Response', assert => {
-  
+
   http.request = (options, cb) => {
     return {
       on: function() {
@@ -219,7 +219,7 @@ test('[spot-fleet] manage parses events and relays LatestStreamLabel through Res
   });
 
   SpotFleet.manage({
-    ResponseURL: 'http://aws.response.com/hello',
+    ResponseURL: 'http://api.mapbox.com/hello',
     PhysicalResourceId: 'abc',
     StackId: 'abc',
     LogicalResourceId: 'abc',

--- a/test/stack-outputs.test.js
+++ b/test/stack-outputs.test.js
@@ -9,7 +9,7 @@ test('[stack-outputs] create handles errors', assert => {
       StackName: 'StackName'
     }, 'describeStacks params');
     return cb(new Error('random error'));
-  }); 
+  });
 
   const stackoutputs = new StackOutputs('StackName', 'us-east-1');
 
@@ -26,7 +26,7 @@ test('[stack-outputs] create handles success', assert => {
       StackName: 'StackName'
     }, 'describeStacks params');
     return cb(null, { Stacks: [ { Outputs: [{ OutputKey: 'First', OutputValue: 'first output' }, { OutputKey: 'Second', OutputValue: 'second output'}] }] });
-  }); 
+  });
 
   const stackoutputs = new StackOutputs('StackName', 'us-east-1');
 
@@ -45,7 +45,7 @@ test('[stack-outputs] update does the same thing as create', assert => {
       StackName: 'StackName'
     }, 'describeStacks params');
     return cb(null, { Stacks: [ { Outputs: [{ OutputKey: 'First', OutputValue: 'first output' }, { OutputKey: 'Second', OutputValue: 'second output'}] }] });
-  }); 
+  });
 
   const stackoutputs = new StackOutputs('StackName', 'us-east-1');
 
@@ -83,11 +83,11 @@ test('[stack-outputs] manage parses events and relays LatestStreamLabel through 
       StackName: 'Stack Name'
     }, 'describeStacks params');
     return cb(null, { Stacks: [ { Outputs: [{ OutputKey: 'First', OutputValue: 'first output' }, { OutputKey: 'Second', OutputValue: 'second output'}] }] });
-  }); 
+  });
 
 
   StackOutputs.manage({
-    ResponseURL: 'http://aws.response.com/hello',
+    ResponseURL: 'http://api.mapbox.com/hello',
     PhysicalResourceId: 'abc',
     StackId: 'abc',
     LogicalResourceId: 'abc',
@@ -108,4 +108,3 @@ test('[stack-outputs] manage parses events and relays LatestStreamLabel through 
   });
 
 });
-


### PR DESCRIPTION
I'm not sufficiently familiar with this stack to understand why the tests were failing when run with the fake URL `aws.response.com` which doesn't resolve. I switched the tests to use a fake  `api.mapbox.com` URL that does resolve and the tests pass, but someone else should definitely look into the test failures (i.e. should this DNS lookup have been mocked as well, or did the original URL just happen to be valid at one point?) 

/cc @mapbox/platform 

```
Error: getaddrinfo ENOTFOUND aws.response.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26) {
  errno: 'ENOTFOUND',
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'aws.response.com'
}
```