### PR TITLE
Build() uses lambda nodejs8.10 runtime

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -64,7 +64,7 @@ function build(params) {
       Description: `Manages ${params.CustomResourceName}`,
       Handler: params.Handler,
       MemorySize: 128,
-      Runtime: 'nodejs6.10',
+      Runtime: 'nodejs8.10',
       Timeout: 30
     }
   };

--- a/test/dynamodb-stream-label.test.js
+++ b/test/dynamodb-stream-label.test.js
@@ -1,7 +1,7 @@
 const DynamoDBStreamLabel = require('../functions/dynamodb-stream-label');
 const test = require('tape');
 const AWS = require('@mapbox/mock-aws-sdk-js');
-const http = require('http');
+const https = require('https');
 
 // Confirm create calls describe table and returns LatestStreamLabel
 // Confirm create handles labelless table
@@ -111,7 +111,7 @@ test('[dynamodb-stream-label] manage parses events and relays LatestStreamLabel 
     });
   });
 
-  http.request = (options, cb) => {
+  https.request = (options, cb) => {
     return {
       on: function() {
         return this;


### PR DESCRIPTION
`.build()` creates a lambda function in some other stack. This PR updates that Lambda function to the `nodejs8.10` runtime, since `nodejs6.10` is officially deprecated.