### PR TITLE
bumping nodejs version for lambda runtime

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -64,7 +64,7 @@ function build(params) {
       Description: `Manages ${params.CustomResourceName}`,
       Handler: params.Handler,
       MemorySize: 128,
-      Runtime: 'nodejs10.x',
+      Runtime: 'nodejs14.x',
       Timeout: 30
     }
   };


### PR DESCRIPTION
We need to update the nodejs version because AWS does not appear to support 10.x anymore.  When trying to update the network-security repo the following error occured:
```
17:30:15Z ap-northeast-1: UPDATE_FAILED DefaultVpcFunction: Resource handler returned message: "The runtime parameter of nodejs10.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 735a0b8f-a004-468a-b1af-cff0789cbcc3, Extended Request ID: null)" (RequestToken: 8572fe7d-00fb-f79c-e65f-21ffc75180a5, HandlerErrorCode: InvalidRequest)
```

The rollback also failed for the same reason.  The only way to get the rollback to complete was by manually updating the node version in the lambda runtime config in the aws console.  