### PR TITLE
mike/feat-TELEMTRAF-7944: add arm-supporting AZ VPC export

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 4.1.0
+
+Adds `FargateArm64PrivateSubnets` to the DefaultVpc resource.
+
 ### 4.0.0
 
 Updates to Node 22.x

--- a/functions/default-vpc.js
+++ b/functions/default-vpc.js
@@ -2,6 +2,8 @@ var AWS = require('aws-sdk');
 var utils = require('../lib/utils');
 var Response = require('../lib/response');
 
+var FARGATE_ARM64_UNSUPPORTED_AZ_IDS = ['use1-az3'];
+
 module.exports = function(event, context) {
   if (!utils.validCloudFormationEvent(event))
     return context.done(null, 'ERROR: Invalid CloudFormation event');
@@ -44,6 +46,9 @@ module.exports = function(event, context) {
 
     info.PublicSubnets = publicSubnets.map((subnet) => subnet.SubnetId);
     info.PrivateSubnets = privateSubnets.map((subnet) => subnet.SubnetId);
+    info.FargateArm64PrivateSubnets = privateSubnets
+      .filter((subnet) => !FARGATE_ARM64_UNSUPPORTED_AZ_IDS.includes(subnet.AvailabilityZoneId))
+      .map((subnet) => subnet.SubnetId);
     info.RouteTable = results[1].RouteTables[0].RouteTableId;
     info.RouteTables = results[1].RouteTables.map((rt) => rt.RouteTableId);
     response.setId(info.VpcId);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/magic-cfn-resources",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Build Lambda-backed custom CloudFormation resources",
   "main": "index.js",
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ You can use `Fn::GetAtt` to obtain the following data:
 - AvailabilityZones: an array of strings representing the VPC's availability zones
 - AvailabilityZoneCount: the number of availability zones
 - PublicSubnets: an array of strings representing the VPC's public subnets
+- PrivateSubnets: an array of strings representing the VPC's private subnets
+- FargateArm64PrivateSubnets: an array of private subnet IDs excluding availability zones where Fargate ARM64 is unsupported
 - RouteTable: the ID for the first route table in the VPC
 - RouteTables: IDs of all of the route tables in the VPC
 

--- a/test/default-vpc.test.js
+++ b/test/default-vpc.test.js
@@ -28,7 +28,8 @@ test('[default VPC] success', (assert) => {
       Subnets: [
         { SubnetId: 'a', AvailabilityZone: '1a', MapPublicIpOnLaunch: true },
         { SubnetId: 'b', AvailabilityZone: '1b', MapPublicIpOnLaunch: true },
-        { SubnetId: 'c', AvailabilityZone: '1c', MapPublicIpOnLaunch: false }
+        { SubnetId: 'c', AvailabilityZone: '1c', AvailabilityZoneId: 'use1-az3', MapPublicIpOnLaunch: false },
+        { SubnetId: 'd', AvailabilityZone: '1d', AvailabilityZoneId: 'use1-az6', MapPublicIpOnLaunch: false }
       ]
     }));
   });
@@ -51,12 +52,13 @@ test('[default VPC] success', (assert) => {
       VpcId: 'vpcid',
       AvailabilityZones: ['1a','1b'],
       AvailabilityZoneCount: 2,
-      PrivateSubnetAvailabilityZones: ['1c'],
-      PrivateSubnetAvailabilityZoneCount: 1,
+      PrivateSubnetAvailabilityZones: ['1c', '1d'],
+      PrivateSubnetAvailabilityZoneCount: 2,
       AzIndexedPublicSubnets: ['a', 'b', { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }],
-      AzIndexedPrivateSubnets: [{ Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, 'c', { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }],
+      AzIndexedPrivateSubnets: [{ Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }, 'c', 'd', { Ref: 'AWS::NoValue' }, { Ref: 'AWS::NoValue' }],
       PublicSubnets: ['a', 'b'],
-      PrivateSubnets: ['c'],
+      PrivateSubnets: ['c', 'd'],
+      FargateArm64PrivateSubnets: ['d'],
       RouteTable: 'x',
       RouteTables: ['x', 'z']
     }, 'returns expected info');


### PR DESCRIPTION
Adds a new `DefaultVpc` output property: `FargateArm64PrivateSubnets`.

This output is an array of private subnet IDs from the default VPC, excluding physical availability zones where AWS Fargate ARM64 is not supported. Today the known unsupported case is `use1-az3` in `us-east-1`, per AWS ECS ARM64 documentation.

This does not change any existing `DefaultVpc` outputs such as `PrivateSubnets`, `PublicSubnets`, `AzIndexedPrivateSubnets`, or `AzIndexedPublicSubnets`. Existing stacks will continue to receive the same attributes they use today; this PR only adds a new attribute for stacks that explicitly opt into it.

## Why

`live-traffic-engine` is migrating Fargate tasks to ARM64 for cost savings. Its legacy CloudFormation/cloudfriend service stack currently uses the shared `vpc-private-subnets` export, which includes `subnet-276c8319` (`us-east-1c` / physical AZ `use1-az3`). Fargate ARM64 does not support `use1-az3`, so ARM64 task placement needs a private subnet set that excludes that AZ while preserving multi-AZ placement.

CDK consumers can filter subnets by AZ, but cloudfriend/raw CFN stacks need either hardcoded subnet IDs or a custom-resource/exported value. This adds a reusable custom-resource attribute so LTE and similar legacy CFN stacks can avoid hardcoding subnet IDs.

## Usage example

A CloudFormation/cloudfriend stack can define the existing custom resource:

```js
DefaultVpc: {
  Type: 'Custom::DefaultVpcLookup',
  Properties: {
    ServiceToken: cf.importValue('default-vpc-lookup'),
  },
},
```

Then use the new attribute for Fargate ARM64 subnet placement:

```js
NetworkConfiguration: {
  AwsvpcConfiguration: {
    AssignPublicIp: 'DISABLED',
    SecurityGroups: [/* ... */],
    Subnets: cf.getAtt('DefaultVpc', 'FargateArm64PrivateSubnets'),
  },
},
```

For LTE in `us-east-1`, this should resolve to the ARM-safe private subnet set equivalent to A/D/E, excluding the private subnet in `use1-az3`.

## Testing

- Updated `test/default-vpc.test.js` to verify `FargateArm64PrivateSubnets` excludes a private subnet with `AvailabilityZoneId: use1-az3` while preserving existing DefaultVpc outputs.
- Local test suite passes: 158 passing.