### PR TITLE
CLOUDPLAT-3162: add npm OIDC publish workflow (magic-cfn-resources)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,13 @@
+name: NPM release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  npm-release:
+    uses: mapbox/gha-public/.github/workflows/workflow-npm-oidc-publish.yml@main
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      create-github-release: true

--- a/contributing.md
+++ b/contributing.md
@@ -76,3 +76,19 @@ Use [JSDoc style comments](http://usejsdoc.org/index.html) and build documentati
 - Try to write functions to have no external dependencies aside from the [AWS SDK for JS](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/index.html).
 - During the create event you must assign your backend resource a PhysicalResourceId. Make sure that this ID will be sufficient to identify the backend resource in a later update or delete event.
 - The update and delete events are particularly challenging. They may or may not be triggered after a resource was actually created, so it is not safe to assume that the resource already exists. Be sure to handle both scenarios or you may end up with a stack that you're unable to delete.
+
+## Releasing a new version
+
+Releases are published to npm via GitHub Actions.
+
+### Steps
+
+1. **Bump the version** in `package.json` (follow [semver](https://semver.org))
+2. **Update `CHANGELOG.md`** with a summary of what changed
+3. **Open a PR**, get it reviewed and merged to `master`
+4. **Trigger the release** from the [Actions tab](../../actions/workflows/npm-release.yml):
+   - Select **NPM release** → **Run workflow** → run from `master`
+
+The workflow will publish to npm and create a GitHub release with auto-generated notes.
+
+> **Note:** Only Mapbox maintainers with write access to this repository can trigger the release workflow. External contributors can open and contribute to PRs, but releases are always cut by the owning team.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/magic-cfn-resources",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Build Lambda-backed custom CloudFormation resources",
   "main": "index.js",
   "directories": {
@@ -32,5 +32,8 @@
   "dependencies": {
     "@mapbox/cloudfriend": "^8.4.0",
     "aws-sdk": "^2.1692.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Adds the reusable [`workflow-npm-oidc-publish`](https://github.com/mapbox/gha-public/blob/main/.github/workflows/workflow-npm-oidc-publish.yml) workflow from `mapbox/gha-public`.

This replaces local/manual `npm publish` with a GitHub Actions workflow using OIDC Trusted Publishing — no npm tokens required.

**Trigger:** manual (`workflow_dispatch`) — run from the Actions tab to publish.

Ticket: https://mapbox.atlassian.net/browse/CLOUDPLAT-3162