### PR TITLE
CLOUDPLAT-3162: fix unittest workflow — use npm ci and correct branch name

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "main"
+      - "master"
 
 jobs:
   test:
@@ -19,5 +19,5 @@ jobs:
           node-version: 22.x
           cache: "npm"
 
-      - run: npm install
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary

Two bugs in `unittest.yml` that allowed a broken `package-lock.json` to slip through undetected:

- `npm install` → `npm ci`: `npm install` silently regenerates the lockfile even with conflict markers; `npm ci` fails immediately on a malformed lockfile
- Push trigger was targeting `main` but default branch is `master`, so pushes to master weren't triggering CI at all

Ticket: https://mapbox.atlassian.net/browse/CLOUDPLAT-3162
