### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (magic-cfn-resources)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,5 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/magic-cfn-resources",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Build Lambda-backed custom CloudFormation resources",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.